### PR TITLE
Fix docstring typo

### DIFF
--- a/invenio_app_rdm/tasks.py
+++ b/invenio_app_rdm/tasks.py
@@ -16,7 +16,7 @@ from .utils.files import send_integrity_report_email
 
 @shared_task()
 def file_integrity_report():
-    """Send a report of uhealthy/missing files to system admins."""
+    """Send a report of unhealthy/missing files to system admins."""
     # First retry verifying files that errored during their last check
     files = FileInstance.query.filter(
         FileInstance.last_check.is_(None),


### PR DESCRIPTION
## Summary
- correct the typo in the `file_integrity_report` docstring

## Testing
- `./run-tests.sh` *(fails: No module named check_manifest)*

------
https://chatgpt.com/codex/tasks/task_e_6844400314f083209623a6a1337897d6